### PR TITLE
chore: bind "ui_action" to toggle behaviour in pause menu

### DIFF
--- a/islands/inside_hub/castle_inside.tscn
+++ b/islands/inside_hub/castle_inside.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://btd2flquf86h0" path="res://islands/inside_hub/stool.tscn" id="3_2l40b"]
 [ext_resource type="Script" path="res://follow_camera.gd" id="3_8r8sj"]
 [ext_resource type="PackedScene" uid="uid://bar7wftpdkyu0" path="res://dialogs/dialog_box.tscn" id="3_ry6jm"]
-[ext_resource type="PackedScene" path="res://pause_menu.tscn" id="4_3u7si"]
+[ext_resource type="PackedScene" uid="uid://bx4enm717273p" path="res://pause_menu.tscn" id="4_3u7si"]
 [ext_resource type="PackedScene" uid="uid://5e0r6jojpuol" path="res://islands/inside_hub/sorting_desk.tscn" id="4_dyp41"]
 [ext_resource type="PackedScene" uid="uid://tsew73160rqy" path="res://shared/door/world_portal.tscn" id="4_ih1bi"]
 [ext_resource type="PackedScene" uid="uid://igunt2eyo7yq" path="res://shared/npc/npc_character.tscn" id="4_k2tdf"]

--- a/pause_menu.gd
+++ b/pause_menu.gd
@@ -6,7 +6,7 @@ extends ColorRect
 
 func _unhandled_input(event):
 	if event.is_action_pressed("ui_cancel"):
-		pause()
+		unpause() if is_visible() else pause()
 
 func _ready():
 	resume_button.pressed.connect(unpause)


### PR DESCRIPTION
A user is likely to hit Esc to go to this menu, so we should follow that intuition and allow an Esc to also exit it.

Small change, was something I immediately noticed when trying to run a dev build.

Best of luck with the project! (hopefully I can provide some more meaningful contributions once I'm more familiar with godot) 