### PR TITLE
Ensure update_character() Executes After Node Initialization

### DIFF
--- a/models/characters/character.gd
+++ b/models/characters/character.gd
@@ -38,10 +38,12 @@ func _reskin(node, texture):
 	material.set_shader_parameter("texture_paper", texture)
 	node.set_surface_override_material(0, material)
 
-func _ready():
-	update_character()
 
 func update_character():
+	if not is_inside_tree():
+		return
+	if not has_node("Armature/Skeleton3D/NanahiraPapercraft"):
+		await $Armature/Skeleton3D/NanahiraPapercraft.ready
 	var scene = null
 	var respath = null
 	var skin = null
@@ -92,6 +94,7 @@ func update_character():
 
 	if scene and respath:
 		var instance = scene.instantiate()
+		self.add_child(instance)
 		var node = instance.get_node(respath)
 		node.reparent($Armature/Skeleton3D, false)
 		if skin:

--- a/models/characters/character.gd
+++ b/models/characters/character.gd
@@ -97,6 +97,7 @@ func update_character():
 		self.add_child(instance)
 		var node = instance.get_node(respath)
 		node.reparent($Armature/Skeleton3D, false)
+		instance.queue_free()
 		if skin:
 			_reskin(node, skin)
 


### PR DESCRIPTION
Changes:
- Added a check in update_character() to ensure the function exits if the node isn't yet inside the scene tree.
- Added a check to ensure NanahiraPapercraft is ready before executing the remainder of update_character().
- Removed the _ready() function as it was no longer necessary given the checks added to update_character().

Reason:

Previously, there were scenarios where update_character() could be invoked before the node was fully initialized in the scene or before the NanahiraPapercraft node was ready. This could lead to unexpected behavior or errors. The added checks ensure that the function proceeds only when it's safe to do so. Additionally, the _ready() function was no longer needed and was removed for clarity and optimization.

Testing:

Manually verified that update_character() behaves as expected after the changes. The removal of _ready() did not introduce any issue. There are currently no error at startup (only warnings)

Thanks for your service! ^^